### PR TITLE
[Feat] 유저 위시리스트 상품 추가 API 구현

### DIFF
--- a/src/main/java/com/sparta/quickreserveproject/controller/UserProductWishController.java
+++ b/src/main/java/com/sparta/quickreserveproject/controller/UserProductWishController.java
@@ -1,0 +1,28 @@
+package com.sparta.quickreserveproject.controller;
+
+import com.sparta.quickreserveproject.dto.UserProductWishAddDto;
+import com.sparta.quickreserveproject.service.UserProductWishService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/wishList")
+public class UserProductWishController {
+
+    @Autowired
+    private UserProductWishService userProductWishService;
+
+    @PostMapping
+    public ResponseEntity<String> addWish(
+            @RequestBody UserProductWishAddDto.Request dto
+//            @AuthenticationPrincipal UserDetailsImpl user // TODO: jwt
+    ) {
+//        Long userPk = user.getUser().getUserPk(); // TODO: JWT에서 유저 ID 추출
+        Long userPk = 1L;
+        dto.setUserPk(userPk);
+        userProductWishService.addWish(dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body("위시리스트에 추가 완료");
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/dto/UserProductWishAddDto.java
+++ b/src/main/java/com/sparta/quickreserveproject/dto/UserProductWishAddDto.java
@@ -1,0 +1,32 @@
+package com.sparta.quickreserveproject.dto;
+
+public class UserProductWishAddDto {
+    public static class Request {
+        private Long userPk;
+        private Long productPk;
+
+        public Request() {
+        }
+
+        public Request(Long userPk, Long productPk) {
+            this.userPk = userPk;
+            this.productPk = productPk;
+        }
+
+        public void setUserPk(Long userPk) {
+            this.userPk = userPk;
+        }
+
+        public void setProductPk(Long productPk) {
+            this.productPk = productPk;
+        }
+
+        public Long getUserPk() {
+            return userPk;
+        }
+
+        public Long getProductPk() {
+            return productPk;
+        }
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/entity/UserProductWish.java
+++ b/src/main/java/com/sparta/quickreserveproject/entity/UserProductWish.java
@@ -1,0 +1,36 @@
+package com.sparta.quickreserveproject.entity;
+
+
+import com.sparta.quickreserveproject.global.entity.CEntity;
+import jakarta.persistence.*;
+
+
+@Entity
+@Table(name = "user_product_wish")
+public class UserProductWish extends CEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_product_wish_pk")
+    private Long userProductWishPk;
+
+    /* TODO: 나중에 교체
+    @ManyToOne
+    @JoinColumn(name = "user_pk", nullable = false)
+    private User userPk; //
+     */
+    @Column
+    private Long user;
+
+    @ManyToOne
+    @JoinColumn(name = "product_pk", nullable = false)
+    private ProductEntity product;
+
+    public UserProductWish() {
+    }
+
+    public UserProductWish(Long user, ProductEntity product) {
+        this.user = user;
+        this.product = product;
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/global/entity/CEntity.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/entity/CEntity.java
@@ -1,0 +1,17 @@
+package com.sparta.quickreserveproject.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(value = AuditingEntityListener.class)
+abstract public class CEntity {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/sparta/quickreserveproject/repository/UserProductWishRepository.java
+++ b/src/main/java/com/sparta/quickreserveproject/repository/UserProductWishRepository.java
@@ -1,0 +1,11 @@
+package com.sparta.quickreserveproject.repository;
+
+import com.sparta.quickreserveproject.entity.UserProductWish;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface UserProductWishRepository extends JpaRepository<UserProductWish, Long> {
+}

--- a/src/main/java/com/sparta/quickreserveproject/service/UserProductWishService.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserProductWishService.java
@@ -1,0 +1,7 @@
+package com.sparta.quickreserveproject.service;
+
+import com.sparta.quickreserveproject.dto.UserProductWishAddDto;
+
+public interface UserProductWishService {
+    void addWish(UserProductWishAddDto.Request dto);
+}

--- a/src/main/java/com/sparta/quickreserveproject/service/UserProductWishServiceImpl.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserProductWishServiceImpl.java
@@ -1,0 +1,28 @@
+package com.sparta.quickreserveproject.service;
+
+import com.sparta.quickreserveproject.dto.UserProductWishAddDto;
+import com.sparta.quickreserveproject.entity.ProductEntity;
+import com.sparta.quickreserveproject.entity.UserProductWish;
+import com.sparta.quickreserveproject.repository.ProductRepository;
+import com.sparta.quickreserveproject.repository.UserProductWishRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserProductWishServiceImpl implements UserProductWishService {
+    @Autowired
+    private UserProductWishRepository userProductWishRepository;
+
+    @Autowired
+//    private ProductService productService; // TODO: 서비스 메서드를 통해 가져오도록 리펙토링 필요
+    private ProductRepository productRepository;
+
+    @Override
+    public void addWish(UserProductWishAddDto.Request dto) {
+        ProductEntity product = productRepository.findById(dto.getProductPk())
+                .orElseThrow(() -> new IllegalArgumentException("해당 상품을 찾을 수 없습니다."));
+
+        UserProductWish userProductWish = new UserProductWish(dto.getUserPk(), product);
+        userProductWishRepository.save(userProductWish);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 구현한 작업 내용 요약
  - [x] 유저 위시리스트 상품 추가 API 구현

## 변경 사항

## 테스트
- 테스트 내용 및 방법
  - [x] Postman으로 API 호출 테스트

## 참고 사항
- User에 관한 Entity 만들어야함
- 나중에 jwt를 통한 유저 인증이 완료되면, jwt를 통해 유저pk를 가져오도록한다
  (현재는 하드코딩으로 유저pk 넣어둠)
- ProductService에서 ProductEntity를 가져오는 메서드를 만들어야한다. 나중에 해당 메서드로 처리하도록 변경한다
  (현재는 직접 ProductRepository에 접근해서 가져오는 걸로 구현)
- Entity는 뒤에 Entitiy를 안붙이기로 리네이밍했다. ProductEntity도 변경해야함