### PR TITLE
[Feat] 유저 회원가입, 자기 정보 불러오기 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "org.springframework.boot:spring-boot-starter-security"
     testImplementation 'org.projectlombok:lombok:1.18.26'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -28,12 +28,16 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    testImplementation 'org.projectlombok:lombok:1.18.26'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/sparta/quickreserveproject/QuickReserveProjectApplication.java
+++ b/src/main/java/com/sparta/quickreserveproject/QuickReserveProjectApplication.java
@@ -3,9 +3,11 @@ package com.sparta.quickreserveproject;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableWebSecurity
 public class QuickReserveProjectApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/sparta/quickreserveproject/controller/UserController.java
+++ b/src/main/java/com/sparta/quickreserveproject/controller/UserController.java
@@ -1,0 +1,20 @@
+package com.sparta.quickreserveproject.controller;
+
+import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
+import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+import com.sparta.quickreserveproject.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @PostMapping
+    public UserCreateResponseDto createUser(@RequestBody UserCreateRequestDto dto) {
+        return userService.createUser(dto);
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/controller/UserController.java
+++ b/src/main/java/com/sparta/quickreserveproject/controller/UserController.java
@@ -2,6 +2,7 @@ package com.sparta.quickreserveproject.controller;
 
 import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
 import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+import com.sparta.quickreserveproject.dto.UserMyInfoResponseDto;
 import com.sparta.quickreserveproject.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -16,5 +17,13 @@ public class UserController {
     @PostMapping
     public UserCreateResponseDto createUser(@RequestBody UserCreateRequestDto dto) {
         return userService.createUser(dto);
+    }
+
+    @GetMapping("/myinfo")
+    public UserMyInfoResponseDto getMyInfo(//            @AuthenticationPrincipal UserDetailsImpl user // TODO: jwt
+    ) {
+//        Long userPk = user.getUser().getUserPk(); // TODO: JWT에서 유저 ID 추출
+        Long userPk = 1L;
+        return userService.getMyInfo(userPk);
     }
 }

--- a/src/main/java/com/sparta/quickreserveproject/dto/UserCreateRequestDto.java
+++ b/src/main/java/com/sparta/quickreserveproject/dto/UserCreateRequestDto.java
@@ -1,0 +1,23 @@
+package com.sparta.quickreserveproject.dto;
+
+import com.sparta.quickreserveproject.entity.User;
+import lombok.*;
+
+
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateRequestDto {
+    private String userId;
+    private String userName;
+    private String userPw;
+    private String userPhoneNum;
+    private String userEmail;
+    private String userAddress;
+    private String userAddressDetail;
+    private User.Gender userGender;
+    private String userSocialType;
+    private String userSocialId;
+}

--- a/src/main/java/com/sparta/quickreserveproject/dto/UserCreateResponseDto.java
+++ b/src/main/java/com/sparta/quickreserveproject/dto/UserCreateResponseDto.java
@@ -1,0 +1,25 @@
+package com.sparta.quickreserveproject.dto;
+
+import com.sparta.quickreserveproject.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserCreateResponseDto {
+    private Long userPk;
+    private String userId;
+    private String userName;
+    private String userPhoneNum;
+    private String userEmail;
+    private String userAddress;
+    private String userAddressDetail;
+    private User.Gender userGender;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/sparta/quickreserveproject/dto/UserMyInfoResponseDto.java
+++ b/src/main/java/com/sparta/quickreserveproject/dto/UserMyInfoResponseDto.java
@@ -1,0 +1,26 @@
+package com.sparta.quickreserveproject.dto;
+
+import com.sparta.quickreserveproject.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserMyInfoResponseDto {
+    private Long userPk;
+    private String userId;
+    private String userName;
+    private String userPhoneNum;
+    private String userEmail;
+    private String userAddress;
+    private String userAddressDetail;
+    private User.Gender userGender;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/sparta/quickreserveproject/entity/User.java
+++ b/src/main/java/com/sparta/quickreserveproject/entity/User.java
@@ -1,0 +1,53 @@
+package com.sparta.quickreserveproject.entity;
+
+import com.sparta.quickreserveproject.global.entity.CUDEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
+
+@Entity
+@Table(name = "user")
+@SQLDelete(sql = "UPDATE product SET deleted_at = now() WHERE product_pk = ?")
+@Where(clause = "deleted_at is null")
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class User extends CUDEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userPk;
+
+    @Column(nullable = false, unique = true)
+    private String userId;
+
+    @Column(nullable = false)
+    private String userName;
+
+    @Column(nullable = false)
+    private String userPw;
+
+    @Column(nullable = false)
+    private String userPhoneNum;
+
+    @Column(nullable = false, unique = true)
+    private String userEmail;
+
+    @Column(nullable = false)
+    private String userAddress;
+
+    private String userAddressDetail;
+
+    @Enumerated(EnumType.STRING)
+    private Gender userGender;
+
+    private String userSocialType;
+
+    private String userSocialId;
+
+    public enum Gender {
+        MALE, FEMALE
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/entity/User.java
+++ b/src/main/java/com/sparta/quickreserveproject/entity/User.java
@@ -1,10 +1,14 @@
 package com.sparta.quickreserveproject.entity;
 
 import com.sparta.quickreserveproject.global.entity.CUDEntity;
+import com.sparta.quickreserveproject.global.util.EncryptionUtil;
+import com.sparta.quickreserveproject.global.util.PasswordUtil;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
+
+import javax.crypto.SecretKey;
 
 @Entity
 @Table(name = "user")
@@ -49,5 +53,34 @@ public class User extends CUDEntity {
 
     public enum Gender {
         MALE, FEMALE
+    }
+
+    private String secretKey;
+
+    @PrePersist
+    @PreUpdate
+    private void encryptSensitiveData() {
+        try {
+            SecretKey key = (secretKey == null) ? EncryptionUtil.generateKey() : EncryptionUtil.decodeKey(secretKey);
+            if (secretKey == null) {
+                this.secretKey = EncryptionUtil.encodeKey(key);
+            }
+            this.userName = EncryptionUtil.encrypt(userName, key);
+            this.userAddress = EncryptionUtil.encrypt(userAddress, key);
+            this.userPw = PasswordUtil.hashPassword(userPw);
+        } catch (Exception e) {
+            throw new RuntimeException("유저 데이터 암호화 과정 중 에러가 발생하였습니다", e);
+        }
+    }
+
+    @PostLoad
+    private void decryptSensitiveData() {
+        try {
+            SecretKey key = EncryptionUtil.decodeKey(secretKey);
+            this.userName = EncryptionUtil.decrypt(userName, key);
+            this.userAddress = EncryptionUtil.decrypt(userAddress, key);
+        } catch (Exception e) {
+            throw new RuntimeException("유저 데이터 복호화 과정 중 에러가 발생하였습니다", e);
+        }
     }
 }

--- a/src/main/java/com/sparta/quickreserveproject/global/config/SecurityConfig.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.sparta.quickreserveproject.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@RequiredArgsConstructor
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .csrf(csrf -> csrf.disable()) // CSRF 비활성화
+                .authorizeHttpRequests(authz -> authz
+                        .anyRequest().permitAll() // 모든 요청 허용 // TODO: 로그인해야지 이용가능하도록 바꾸기
+                )
+                .formLogin(form -> form.disable()) // 폼 기반 로그인 비활성화
+                .httpBasic(basic -> basic.disable()) // HTTP Basic 인증 비활성화
+                .build();
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/global/entity/CEntity.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/entity/CEntity.java
@@ -3,6 +3,7 @@ package com.sparta.quickreserveproject.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -10,6 +11,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(value = AuditingEntityListener.class)
+@Getter
 abstract public class CEntity {
     @CreatedDate
     @Column(name = "created_at", updatable = false)

--- a/src/main/java/com/sparta/quickreserveproject/global/entity/CUDEntity.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/entity/CUDEntity.java
@@ -3,6 +3,7 @@ package com.sparta.quickreserveproject.global.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 
 @MappedSuperclass
 @EntityListeners(value = AuditingEntityListener.class)
+@Getter
 abstract public class CUDEntity {
 
 

--- a/src/main/java/com/sparta/quickreserveproject/global/util/EncryptionUtil.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/util/EncryptionUtil.java
@@ -1,0 +1,41 @@
+package com.sparta.quickreserveproject.global.util;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.util.Base64;
+
+public class EncryptionUtil {
+    private static final String ALGORITHM = "AES";
+
+    public static SecretKey generateKey() throws Exception {
+        KeyGenerator keyGenerator = KeyGenerator.getInstance(ALGORITHM);
+        keyGenerator.init(256);
+        return keyGenerator.generateKey();
+    }
+
+    public static String encodeKey(SecretKey key) {
+        return Base64.getEncoder().encodeToString(key.getEncoded());
+    }
+
+    public static SecretKey decodeKey(String encodedKey) {
+        byte[] decodedKey = Base64.getDecoder().decode(encodedKey);
+        return new SecretKeySpec(decodedKey, 0, decodedKey.length, ALGORITHM);
+    }
+
+    public static String encrypt(String data, SecretKey key) throws Exception {
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        byte[] encryptedBytes = cipher.doFinal(data.getBytes());
+        return Base64.getEncoder().encodeToString(encryptedBytes);
+    }
+
+    public static String decrypt(String encryptedData, SecretKey key) throws Exception {
+        Cipher cipher = Cipher.getInstance(ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, key);
+        byte[] decodedBytes = Base64.getDecoder().decode(encryptedData);
+        byte[] decryptedBytes = cipher.doFinal(decodedBytes);
+        return new String(decryptedBytes);
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/global/util/PasswordUtil.java
+++ b/src/main/java/com/sparta/quickreserveproject/global/util/PasswordUtil.java
@@ -1,0 +1,15 @@
+package com.sparta.quickreserveproject.global.util;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordUtil {
+    private static final BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+    public static String hashPassword(String rawPassword) {
+        return encoder.encode(rawPassword);
+    }
+
+    public static boolean matches(String rawPassword, String hashedPassword) {
+        return encoder.matches(rawPassword, hashedPassword);
+    }
+}

--- a/src/main/java/com/sparta/quickreserveproject/repository/UserRepository.java
+++ b/src/main/java/com/sparta/quickreserveproject/repository/UserRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUserEmail(String userEmail);
+    boolean existsByUserId(String userId);
 }

--- a/src/main/java/com/sparta/quickreserveproject/repository/UserRepository.java
+++ b/src/main/java/com/sparta/quickreserveproject/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.sparta.quickreserveproject.repository;
+import com.sparta.quickreserveproject.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUserEmail(String userEmail);
+}

--- a/src/main/java/com/sparta/quickreserveproject/service/UserService.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserService.java
@@ -2,7 +2,10 @@ package com.sparta.quickreserveproject.service;
 
 import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
 import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+import com.sparta.quickreserveproject.dto.UserMyInfoResponseDto;
 
 public interface UserService {
     UserCreateResponseDto createUser(UserCreateRequestDto dto);
+
+    UserMyInfoResponseDto getMyInfo(Long userPk);
 }

--- a/src/main/java/com/sparta/quickreserveproject/service/UserService.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserService.java
@@ -1,0 +1,8 @@
+package com.sparta.quickreserveproject.service;
+
+import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
+import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+
+public interface UserService {
+    UserCreateResponseDto createUser(UserCreateRequestDto dto);
+}

--- a/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
@@ -3,10 +3,13 @@ package com.sparta.quickreserveproject.service;
 import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
 import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
 import com.sparta.quickreserveproject.entity.User;
+import com.sparta.quickreserveproject.global.util.EncryptionUtil;
 import com.sparta.quickreserveproject.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import javax.crypto.SecretKey;
 
 @Service
 @RequiredArgsConstructor
@@ -19,32 +22,44 @@ public class UserServiceImpl implements UserService {
         if (userRepository.existsByUserEmail(dto.getUserEmail())) {
             throw new IllegalArgumentException("Email이 이미존재합니다");
         }
+        if (userRepository.existsByUserId(dto.getUserId())) {
+            throw new IllegalArgumentException("Id가 이미존재합니다");
+        }
+        try {
+            User user = User.builder()
+                    .userId(dto.getUserId())
+                    .userName(dto.getUserName())
+                    .userPw(dto.getUserPw())
+                    .userPhoneNum(dto.getUserPhoneNum())
+                    .userEmail(dto.getUserEmail())
+                    .userAddress(dto.getUserAddress())
+                    .userAddressDetail(dto.getUserAddressDetail())
+                    .userGender(dto.getUserGender())
+                    .userSocialType(dto.getUserSocialType())
+                    .userSocialId(dto.getUserSocialId())
+                    .build();
 
-        User user = User.builder()
-                .userId(dto.getUserId())
-                .userName(dto.getUserName())
-                .userPw(dto.getUserPw())
-                .userPhoneNum(dto.getUserPhoneNum())
-                .userEmail(dto.getUserEmail())
-                .userAddress(dto.getUserAddress())
-                .userAddressDetail(dto.getUserAddressDetail())
-                .userGender(dto.getUserGender())
-                .userSocialType(dto.getUserSocialType())
-                .userSocialId(dto.getUserSocialId())
-                .build();
+            userRepository.save(user);
 
-        user = userRepository.save(user);
-        return UserCreateResponseDto.builder()
-                .userPk(user.getUserPk())
-                .userId(user.getUserId())
-                .userName(user.getUserName())
-                .userPhoneNum(user.getUserPhoneNum())
-                .userEmail(user.getUserEmail())
-                .userAddress(user.getUserAddress())
-                .userAddressDetail(user.getUserAddressDetail())
-                .userGender(user.getUserGender())
-                .createdAt(user.getCreatedAt())
-                .updatedAt(user.getUpdatedAt())
-                .build();
+            SecretKey key = EncryptionUtil.decodeKey(user.getSecretKey());
+            String decryptedUserName = EncryptionUtil.decrypt(user.getUserName(), key);
+            String decryptedUserAddress = EncryptionUtil.decrypt(user.getUserAddress(), key);
+
+
+            return UserCreateResponseDto.builder()
+                    .userPk(user.getUserPk())
+                    .userId(user.getUserId())
+                    .userName(decryptedUserName)
+                    .userPhoneNum(user.getUserPhoneNum())
+                    .userEmail(user.getUserEmail())
+                    .userAddress(decryptedUserAddress)
+                    .userAddressDetail(user.getUserAddressDetail())
+                    .userGender(user.getUserGender())
+                    .createdAt(user.getCreatedAt())
+                    .updatedAt(user.getUpdatedAt())
+                    .build();
+        } catch (Exception e) {
+            throw new RuntimeException("유저 생성 중 에러가 발생하였습는니다", e);
+        }
     }
 }

--- a/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.sparta.quickreserveproject.service;
 
 import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
 import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+import com.sparta.quickreserveproject.dto.UserMyInfoResponseDto;
 import com.sparta.quickreserveproject.entity.User;
 import com.sparta.quickreserveproject.global.util.EncryptionUtil;
 import com.sparta.quickreserveproject.repository.UserRepository;
@@ -61,5 +62,24 @@ public class UserServiceImpl implements UserService {
         } catch (Exception e) {
             throw new RuntimeException("유저 생성 중 에러가 발생하였습는니다", e);
         }
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public UserMyInfoResponseDto getMyInfo(Long userPk) {
+        User user = userRepository.findById(userPk)
+                .orElseThrow(() -> new IllegalArgumentException("해당 ID를 가진 유저가 없습니다"));
+        return UserMyInfoResponseDto.builder()
+                .userPk(user.getUserPk())
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userPhoneNum(user.getUserPhoneNum())
+                .userEmail(user.getUserEmail())
+                .userAddress(user.getUserAddress())
+                .userAddressDetail(user.getUserAddressDetail())
+                .userGender(user.getUserGender())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
     }
 }

--- a/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
+++ b/src/main/java/com/sparta/quickreserveproject/service/UserServiceImpl.java
@@ -1,0 +1,50 @@
+package com.sparta.quickreserveproject.service;
+
+import com.sparta.quickreserveproject.dto.UserCreateRequestDto;
+import com.sparta.quickreserveproject.dto.UserCreateResponseDto;
+import com.sparta.quickreserveproject.entity.User;
+import com.sparta.quickreserveproject.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    public UserCreateResponseDto createUser(UserCreateRequestDto dto) {
+        if (userRepository.existsByUserEmail(dto.getUserEmail())) {
+            throw new IllegalArgumentException("Email이 이미존재합니다");
+        }
+
+        User user = User.builder()
+                .userId(dto.getUserId())
+                .userName(dto.getUserName())
+                .userPw(dto.getUserPw())
+                .userPhoneNum(dto.getUserPhoneNum())
+                .userEmail(dto.getUserEmail())
+                .userAddress(dto.getUserAddress())
+                .userAddressDetail(dto.getUserAddressDetail())
+                .userGender(dto.getUserGender())
+                .userSocialType(dto.getUserSocialType())
+                .userSocialId(dto.getUserSocialId())
+                .build();
+
+        user = userRepository.save(user);
+        return UserCreateResponseDto.builder()
+                .userPk(user.getUserPk())
+                .userId(user.getUserId())
+                .userName(user.getUserName())
+                .userPhoneNum(user.getUserPhoneNum())
+                .userEmail(user.getUserEmail())
+                .userAddress(user.getUserAddress())
+                .userAddressDetail(user.getUserAddressDetail())
+                .userGender(user.getUserGender())
+                .createdAt(user.getCreatedAt())
+                .updatedAt(user.getUpdatedAt())
+                .build();
+    }
+}


### PR DESCRIPTION
## 작업 내용
  - [x] 유저 회원가입 API 구현
  - [x] 유저 민감정보(이름, 주소) AES 암복호화, 비밀번호 BCrypt 암호화 구현
  - [x] 유저 자기 정보 불러오기 API 구현

## 변경 사항
  - [x] lombok 사용, 디펜던시 추가

## 테스트
- 테스트 내용 및 방법
  - [x] Postman으로 API 호출 테스트

## 참고 사항
- 민감정보들은 Entity에서 저장되기전/로드후에 암/복호화 하도록 설정함
- security 우선 모든 url이 인증 필요없도록 뚫어놓음 (JWT 도입시 막을 것)